### PR TITLE
Use patches, split owned/borrowed msg defs

### DIFF
--- a/tally-firmware/Cargo.toml
+++ b/tally-firmware/Cargo.toml
@@ -31,7 +31,7 @@ heapless = "0.8.0"
 log = "0.4.27"
 micromath = "2.1.0"
 postcard = "1.1.1"
-postcard-rpc = { version = "0.11.9", path = "../../postcard-rpc/source/postcard-rpc", features = [ "defmt", "embassy-net-tcp-server", "embassy-usb-0_4-server", "embassy-usb-0_3-server"], default-features = false }
+postcard-rpc = { version = "0.11.9", features = [ "defmt", "embassy-net-tcp-server", "embassy-usb-0_4-server", "embassy-usb-0_3-server"], default-features = false }
 postcard-schema = "0.2.1"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 smart-leds = "0.4.0"

--- a/tally-rpc/Cargo.lock
+++ b/tally-rpc/Cargo.lock
@@ -370,6 +370,8 @@ dependencies = [
 [[package]]
 name = "postcard-rpc"
 version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af390b4b4c1a3a187293bfef773157c75a06f935eeae147c981ee1d958652ea"
 dependencies = [
  "defmt 0.3.100",
  "heapless 0.8.0",

--- a/tally-rpc/Cargo.toml
+++ b/tally-rpc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-postcard-rpc = { version = "0.11.9", path = "../../postcard-rpc/source/postcard-rpc", features = ["defmt"], default-features = false}
+postcard-rpc = { version = "0.11.9", features = ["defmt"], default-features = false}
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 postcard-schema = "0.2.1"
 embassy-net = { version = "0.7.0", default-features = false, features = ["dhcpv4", "medium-ethernet", "proto-ipv4", "tcp"] }
@@ -12,3 +12,6 @@ heapless = "0.8.0"
 
 [lib]
 path = "src/lib.rs"
+
+[features]
+use-std = []

--- a/tally-rpc/src/lib.rs
+++ b/tally-rpc/src/lib.rs
@@ -1,2 +1,2 @@
-#![no_std]
+#![cfg_attr(not(any(test, feature = "use-std")), no_std)]
 pub mod rpc;

--- a/tally-rpc/src/rpc.rs
+++ b/tally-rpc/src/rpc.rs
@@ -5,12 +5,13 @@ use serde::{Deserialize, Serialize};
 
 endpoints! {
     list = ENDPOINTS_LIST;
-    | EndpointTy            | RequestTy     | ResponseTy        | Path         |
-    | ----------            | ---------     | ----------        | ----         |
-    | InfoEndpoint          | ()            | InfoResponse<'a>  | "info"       |
-    | SetConfigEndpoint     | Config        | ()                | "setconf"    |
-    | StartColorTest        | ()            | bool              | "startcolor" |
-    | StopColorTest         | ()            | bool              | "stopcolor"  |
+    | EndpointTy            | RequestTy     | ResponseTy        | Path         | Cfg                            |
+    | ----------            | ---------     | ----------        | ----         | ---                            |
+    | InfoEndpoint          | ()            | InfoResponse<'a>  | "info"       | cfg(not(feature = "use-std"))  |
+    | InfoEndpoint          | ()            | InfoResponse      | "info"       | cfg(feature = "use-std")       |
+    | SetConfigEndpoint     | Config        | ()                | "setconf"    |                                |
+    | StartColorTest        | ()            | bool              | "startcolor" |                                |
+    | StopColorTest         | ()            | bool              | "stopcolor"  |                                |
 }
 
 topics! {
@@ -72,9 +73,18 @@ impl Default for Config {
 
 // Responses
 
+#[cfg(not(feature = "use-std"))]
 #[derive(Serialize, Deserialize, Schema, Debug)]
 pub struct InfoResponse<'a> {
     pub name: &'a str,
+    pub mac: [u8; 6],
+    pub fw_version: (u8, u8, u8),
+}
+
+#[cfg(feature = "use-std")]
+#[derive(Serialize, Deserialize, Schema, Debug)]
+pub struct InfoResponse {
+    pub name: String,
     pub mac: [u8; 6],
     pub fw_version: (u8, u8, u8),
 }

--- a/tally-tool/Cargo.lock
+++ b/tally-tool/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -760,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1913,6 +1913,7 @@ dependencies = [
 [[package]]
 name = "postcard-rpc"
 version = "0.11.9"
+source = "git+https://github.com/wlcx/postcard-rpc?rev=78746802307073a84c090d01d12335d3a2611075#78746802307073a84c090d01d12335d3a2611075"
 dependencies = [
  "cobs",
  "defmt 0.3.100",
@@ -2111,7 +2112,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2124,7 +2125,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2865,7 +2866,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/tally-tool/Cargo.toml
+++ b/tally-tool/Cargo.toml
@@ -11,7 +11,11 @@ name = "tallycli"
 
 [dependencies]
 eframe = { version = "0.31.1", default-features = false, features = ["glow", "default_fonts"] }
-postcard-rpc = { version = "0.11.9", path = "../../postcard-rpc/source/postcard-rpc", default-features = false, features = ["tcp", "use-std"] }
-tally-rpc = { version = "0.1.0", path = "../tally-rpc" }
+postcard-rpc = { version = "0.11.9", default-features = false, features = ["tcp", "use-std"] }
+tally-rpc = { version = "0.1.0", path = "../tally-rpc", features = ["use-std"] }
 tokio = { version = "1.45.0", features = ["net", "rt-multi-thread"] }
 tracing-subscriber = "0.3.19"
+
+[patch.crates-io.postcard-rpc]
+git = "https://github.com/wlcx/postcard-rpc"
+rev = "78746802307073a84c090d01d12335d3a2611075"

--- a/tally-tool/src/bin/tallycli.rs
+++ b/tally-tool/src/bin/tallycli.rs
@@ -13,7 +13,7 @@ async fn main() {
         .unwrap()
         .next()
         .unwrap();
-    let cli = HostClient::<WireErr>::connect_tcp(addr).await;
+    let cli = HostClient::<postcard_rpc::standard_icd::WireError>::connect_tcp(addr).await;
     println!("connected");
     let info: InfoResponse = cli.send_resp::<InfoEndpoint>(&()).await.unwrap();
     println!("{:?}", info);

--- a/tally-tool/src/bin/tallycli.rs
+++ b/tally-tool/src/bin/tallycli.rs
@@ -13,7 +13,7 @@ async fn main() {
         .unwrap()
         .next()
         .unwrap();
-    let cli = HostClient::<postcard_rpc::standard_icd::WireError>::connect_tcp(addr).await;
+    let cli = HostClient::<WireErr>::connect_tcp(addr).await;
     println!("connected");
     let info: InfoResponse = cli.send_resp::<InfoEndpoint>(&()).await.unwrap();
     println!("{:?}", info);


### PR DESCRIPTION
Uses cargo patches so it will build on other's PCs, add feature to switch between owned/borrowed message definitions